### PR TITLE
Add send(), recv() for connected UDP sockets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miow"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Hey there!

I'm building some high-perf UDP server for netcode.io and noticed that mio was missing send() and recv() on connected UDP sockets. This is the first part of getting those operations over into mio.

Let me know if there's anything you'd like changed, I didn't see an contribution guidelines so I just followed what I saw in the repo.