### PR TITLE
Overlapped status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ winapi = "0.2"
 kernel32-sys = "0.2"
 ws2_32-sys = "0.2"
 net2 = { version = "0.2.5", default-features = false }
+lazy_static = "0.2.8"
+libloading = "0.4.0"
 
 [dev-dependencies]
 rand = "0.3"


### PR DESCRIPTION
This makes it possible in general to reliably determine whether an I/O operation succeeded. For example, it enables graceful handling of TCP connect failures.

This PR enables https://github.com/carllerche/mio/pull/603.

Many thanks to @retep998 for his patient advice over the course of this work--this is my first foray into Windows systems programming and I certainly would have had a much more difficult time on my own.