### PR TITLE
migrate to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ abstractions.
 """
 
 [dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
-ws2_32-sys = "0.2"
+winapi = { version = "0.3.2", features = ["std", "fileapi", "handleapi", "ioapiset", "minwindef", "namedpipeapi", "ntdef", "winerror", "winsock2", "ws2def", "ws2ipdef"] }
 net2 = { version = "0.2.5", default-features = false }
 
 [dev-dependencies]
 rand = "0.3"
+
+[replace]
+"winapi:0.3.2" = { git = "https://github.com/retep998/winapi-rs", branch = "0.3" }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,8 +1,12 @@
 use std::io;
 use std::cmp;
 
-use winapi::*;
-use kernel32::*;
+use winapi::shared::minwindef::*;
+use winapi::shared::ntdef::HANDLE;
+use winapi::shared::winerror::*;
+use winapi::um::fileapi::*;
+use winapi::um::handleapi::*;
+use winapi::um::minwinbase::*;
 
 #[derive(Debug)]
 pub struct Handle(HANDLE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,8 @@
 #![allow(bad_style)]
 #![doc(html_root_url = "https://docs.rs/miow/0.1/x86_64-pc-windows-msvc/")]
 
-extern crate kernel32;
 extern crate net2;
 extern crate winapi;
-extern crate ws2_32;
 
 #[cfg(test)] extern crate rand;
 
@@ -16,7 +14,8 @@ use std::cmp;
 use std::io;
 use std::time::Duration;
 
-use winapi::*;
+use winapi::shared::minwindef::*;
+use winapi::um::winbase::*;
 
 macro_rules! t {
     ($e:expr) => (match $e {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -8,8 +8,15 @@ use std::os::windows::ffi::*;
 use std::os::windows::io::*;
 use std::time::Duration;
 
-use winapi::*;
-use kernel32::*;
+use winapi::shared::ntdef::HANDLE;
+use winapi::shared::minwindef::*;
+use winapi::shared::winerror::*;
+use winapi::um::fileapi::*;
+use winapi::um::handleapi::*;
+use winapi::um::ioapiset::*;
+use winapi::um::minwinbase::*;
+use winapi::um::namedpipeapi::*;
+use winapi::um::winbase::*;
 use handle::Handle;
 
 /// Readable half of an anonymous pipe.


### PR DESCRIPTION
This is not ready to land as is, since it requires another winapi release due to a missing type.
This is a breaking change.