### PR TITLE
Use overlapped interface with `NamedPipe`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ features = [
   "minwindef",
   "namedpipeapi",
   "ntdef",
+  "synchapi",
   "winerror",
   "winsock2",
   "ws2def",

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::io;
 use std::mem;
 
 use winapi::shared::ntdef::HANDLE;
@@ -24,6 +25,19 @@ impl Overlapped {
     /// notified via an I/O Completion Port.
     pub fn zero() -> Overlapped {
         Overlapped(unsafe { mem::zeroed() })
+    }
+
+    /// Creates a new `Overlapped` with an initialized non-null `hEvent`.  The caller is
+    /// responsible for calling `CloseHandle` on the `hEvent` field of the returned
+    /// `Overlapped`.
+    pub fn initialize_with_event() -> io::Result<Overlapped> {
+        let event = unsafe {CreateEvent(ptr::null(), TRUE, FALSE, ptr::null())});
+        if event == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        let overlapped = Self::zero();
+        overlapped.set_event(event);
+        Ok(overlapped)
     }
 
     /// Creates a new `Overlapped` function pointer from the underlying

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -1,9 +1,12 @@
 use std::fmt;
 use std::io;
 use std::mem;
+use std::ptr;
 
 use winapi::shared::ntdef::HANDLE;
+use winapi::um::handleapi::*;
 use winapi::um::minwinbase::*;
+use winapi::um::synchapi::*;
 
 /// A wrapper around `OVERLAPPED` to provide "rustic" accessors and
 /// initializers.
@@ -31,11 +34,11 @@ impl Overlapped {
     /// responsible for calling `CloseHandle` on the `hEvent` field of the returned
     /// `Overlapped`.
     pub fn initialize_with_event() -> io::Result<Overlapped> {
-        let event = unsafe {CreateEvent(ptr::null(), TRUE, FALSE, ptr::null())});
+        let event = unsafe {CreateEventW(ptr::null_mut(), 1i32, 0i32, ptr::null())};
         if event == INVALID_HANDLE_VALUE {
             return Err(io::Error::last_os_error());
         }
-        let overlapped = Self::zero();
+        let mut overlapped = Self::zero();
         overlapped.set_event(event);
         Ok(overlapped)
     }

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -7,7 +7,6 @@ use winapi::shared::ntdef::{
     HANDLE,
     NULL,
 };
-use winapi::um::handleapi::*;
 use winapi::um::minwinbase::*;
 use winapi::um::synchapi::*;
 
@@ -35,9 +34,10 @@ impl Overlapped {
 
     /// Creates a new `Overlapped` with an initialized non-null `hEvent`.  The caller is
     /// responsible for calling `CloseHandle` on the `hEvent` field of the returned
-    /// `Overlapped`.
-    pub fn initialize_with_event() -> io::Result<Overlapped> {
-        let event = unsafe {CreateEventW(ptr::null_mut(), 1i32, 0i32, ptr::null())};
+    /// `Overlapped`.  The event is created with `bManualReset` set to `FALSE`, meaning after a
+    /// single thread waits on the event, it will be reset.
+    pub fn initialize_with_autoreset_event() -> io::Result<Overlapped> {
+        let event = unsafe {CreateEventW(ptr::null_mut(), 0i32, 0i32, ptr::null())};
         if event == NULL {
             return Err(io::Error::last_os_error());
         }

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -3,7 +3,10 @@ use std::io;
 use std::mem;
 use std::ptr;
 
-use winapi::shared::ntdef::HANDLE;
+use winapi::shared::ntdef::{
+    HANDLE,
+    NULL,
+};
 use winapi::um::handleapi::*;
 use winapi::um::minwinbase::*;
 use winapi::um::synchapi::*;
@@ -35,7 +38,7 @@ impl Overlapped {
     /// `Overlapped`.
     pub fn initialize_with_event() -> io::Result<Overlapped> {
         let event = unsafe {CreateEventW(ptr::null_mut(), 1i32, 0i32, ptr::null())};
-        if event == INVALID_HANDLE_VALUE {
+        if event == NULL {
             return Err(io::Error::last_os_error());
         }
         let mut overlapped = Self::zero();


### PR DESCRIPTION
This pull request has two primary changes:
1. Using `GetOverlappedResult` instead of `lpNumberOfBytes{Read,Written}` in `ReadFile` and `WriteFile` for `read_overlapped` and `write_overlapped`, respectively.  According to https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-readfile and https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile, if the file was opened with `FILE_FLAG_OVERLAPPED`,
> The lpNumberOfBytesWritten parameter should be set to NULL. To get the number of bytes written, use the GetOverlappedResult function.

2. Noting that all `NamedPipe`s are created with `FILE_FLAG_OVERLAPPED`, their `read` and `write` implementations should use the `lpOverlapped` parameter.  Create a variant that will wait for the completion before returning to satisfy the simple `read` and `write` interface.

This seemed the simplest change that didn't break the interface defaults but am open to suggestions / alternate solutions that use the overlapped interface with handles opened using `FILE_FLAG_OVERLAPPED`.